### PR TITLE
Perf trials

### DIFF
--- a/benches/rustlatin.rs
+++ b/benches/rustlatin.rs
@@ -73,6 +73,34 @@ fn bench_rustlatin_fastester(b: &mut Bencher) {
         rustlatin_fastester(&str);
     });
 }
+fn bench_rustlatin_fastester2(b: &mut Bencher) {
+    let str = long_str();
+    b.iter(|| {
+        rustlatin_fastester2(SHORT_STR);
+        rustlatin_fastester2(&str);
+    });
+}
+fn bench_rustlatin_fastester3(b: &mut Bencher) {
+    let str = long_str();
+    b.iter(|| {
+        rustlatin_fastester3(SHORT_STR);
+        rustlatin_fastester3(&str);
+    });
+}
+fn bench_rustlatin_fastester4(b: &mut Bencher) {
+    let str = long_str();
+    b.iter(|| {
+        rustlatin_fastester3(SHORT_STR);
+        rustlatin_fastester3(&str);
+    });
+}
+fn bench_rustlatin_fastester5(b: &mut Bencher) {
+    let str = long_str();
+    b.iter(|| {
+        rustlatin_fastester3(SHORT_STR);
+        rustlatin_fastester3(&str);
+    });
+}
 
 fn bench_rustlatin_rayon(b: &mut Bencher) {
     let str = long_str();
@@ -92,16 +120,20 @@ fn bench_rustlatin_rayon_map(b: &mut Bencher) {
 
 benchmark_group!(
     benches,
-    bench_rustlatin,
-    bench_rustlatin_map,
-    bench_rustlatin_faster,
-    bench_rustlatin_fastest,
-    bench_rustlatin_fastest_simd,
-    bench_rustlatin_fastest_match,
-    bench_rustlatin_fastest_map,
+    //    bench_rustlatin,
+    //    bench_rustlatin_map,
+    //    bench_rustlatin_faster,
+    //    bench_rustlatin_fastest,
+    //    bench_rustlatin_fastest_simd,
+    //    bench_rustlatin_fastest_match,
+    //    bench_rustlatin_fastest_map,
     bench_rustlatin_fastester,
-    bench_rustlatin_rayon,
-    bench_rustlatin_rayon_map,
+    bench_rustlatin_fastester2,
+    bench_rustlatin_fastester3,
+    bench_rustlatin_fastester4,
+    bench_rustlatin_fastester5,
+    //    bench_rustlatin_rayon,
+    //    bench_rustlatin_rayon_map,
 );
 
 benchmark_main!(benches);

--- a/benches/rustlatin.rs
+++ b/benches/rustlatin.rs
@@ -120,20 +120,20 @@ fn bench_rustlatin_rayon_map(b: &mut Bencher) {
 
 benchmark_group!(
     benches,
-    //    bench_rustlatin,
-    //    bench_rustlatin_map,
-    //    bench_rustlatin_faster,
-    //    bench_rustlatin_fastest,
-    //    bench_rustlatin_fastest_simd,
-    //    bench_rustlatin_fastest_match,
-    //    bench_rustlatin_fastest_map,
+    bench_rustlatin,
+    bench_rustlatin_map,
+    bench_rustlatin_faster,
+    bench_rustlatin_fastest,
+    bench_rustlatin_fastest_simd,
+    bench_rustlatin_fastest_match,
+    bench_rustlatin_fastest_map,
     bench_rustlatin_fastester,
     bench_rustlatin_fastester2,
     bench_rustlatin_fastester3,
     bench_rustlatin_fastester4,
     bench_rustlatin_fastester5,
-    //    bench_rustlatin_rayon,
-    //    bench_rustlatin_rayon_map,
+    bench_rustlatin_rayon,
+    bench_rustlatin_rayon_map,
 );
 
 benchmark_main!(benches);

--- a/benches/rustlatin.rs
+++ b/benches/rustlatin.rs
@@ -90,15 +90,15 @@ fn bench_rustlatin_fastester3(b: &mut Bencher) {
 fn bench_rustlatin_fastester4(b: &mut Bencher) {
     let str = long_str();
     b.iter(|| {
-        rustlatin_fastester3(SHORT_STR);
-        rustlatin_fastester3(&str);
+        rustlatin_fastester4(SHORT_STR);
+        rustlatin_fastester4(&str);
     });
 }
 fn bench_rustlatin_fastester5(b: &mut Bencher) {
     let str = long_str();
     b.iter(|| {
-        rustlatin_fastester3(SHORT_STR);
-        rustlatin_fastester3(&str);
+        rustlatin_fastester5(SHORT_STR);
+        rustlatin_fastester5(&str);
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,16 +333,19 @@ pub fn rustlatin_fastester4(sentence: &str) -> String {
 
 // Notice the use of `split(|c| c == ' ')` - very handy function!
 pub fn rustlatin_fastester5(sentence: &str) -> String {
-    let mut result: String = String::with_capacity(sentence.len());
+    let mut result: Vec<u8> = Vec::with_capacity(sentence.len());
     for word in sentence.split(|c| c == ' ') {
         let vowel = word.starts_with(|c| is_vowel_fast4(c as u8));
         if vowel {
-            result.push_str(&("sr".to_owned() + word + " "));
+            result.extend_from_slice(b"sr");
+            result.extend_from_slice(word.as_bytes());
         } else {
-            result.push_str(&(word.to_owned() + "rs "));
+            result.extend_from_slice(word.as_bytes());
+            result.extend_from_slice(b"rs");
         }
+        result.extend_from_slice(b" ");
     }
-    result
+    unsafe { String::from_utf8_unchecked(result) }
 }
 #[test]
 fn rustlatin_fastester2_test() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use lazy_static;
 use packed_simd_2::u8x32;
 use rayon::prelude::*;
+use std::ascii::AsciiExt;
 use std::collections::{HashSet, VecDeque};
 use std::str;
 
@@ -249,6 +250,125 @@ pub fn rustlatin_fastester(sentence: &str) -> String {
     }
 
     result
+}
+
+// Only change: `split_ascii_whitespace`
+pub fn rustlatin_fastester2(sentence: &str) -> String {
+    let words: Vec<&str> = sentence.split_ascii_whitespace().collect();
+    let mut result = String::with_capacity(sentence.len() + words.len() * 2);
+
+    for (index, word) in words.iter().enumerate() {
+        let first_char = word.chars().next().unwrap();
+        let vowel = is_vowel(first_char);
+        if vowel {
+            result.push_str("sr");
+        }
+        result.push_str(word);
+        if !vowel {
+            result.push_str("rs");
+        }
+        if index < words.len() - 1 {
+            result.push(' ');
+        }
+    }
+
+    result
+}
+#[inline(always)]
+fn is_vowel_fast2(c: u8) -> bool {
+    match c {
+        b'A' | b'a' | b'E' | b'e' | b'I' | b'i' | b'O' | b'o' | b'U' | b'u' => true,
+        _ => false,
+    }
+}
+pub fn rustlatin_fastester3(sentence: &str) -> String {
+    let words: Vec<&str> = sentence.split_ascii_whitespace().collect();
+    let mut result = String::with_capacity(sentence.len() + words.len() * 2);
+
+    for (index, word) in words.iter().enumerate() {
+        let first_char = (word).bytes().next().unwrap();
+        let vowel = is_vowel_fast2(first_char);
+        if vowel {
+            result.push_str("sr");
+        }
+        result.push_str(word);
+        if !vowel {
+            result.push_str("rs");
+        }
+        if index < words.len() - 1 {
+            result.push(' ');
+        }
+    }
+
+    result
+}
+
+#[inline(always)]
+pub fn is_vowel_fast4(c: u8) -> bool {
+    match c {
+        b'a' | b'e' | b'i' | b'o' | b'u' => true,
+        _ => false,
+    }
+}
+
+// working on raw byte values with `b".."` style tricks can lead
+// to some predictable perf gains - kinda sad I couldn't find it here
+pub fn rustlatin_fastester4(sentence: &str) -> String {
+    let words: Vec<&str> = sentence.split_ascii_whitespace().collect();
+    let mut result: Vec<u8> = Vec::with_capacity(sentence.len() + words.len() * 2);
+    words.iter().for_each(|word| {
+        let vowel = word.starts_with(|c| is_vowel_fast4(c as u8));
+        if vowel {
+            result.extend_from_slice(b"sr");
+            result.extend_from_slice(word.as_bytes());
+        } else {
+            result.extend_from_slice(word.as_bytes());
+            result.extend_from_slice(b"rs");
+        }
+        result.extend_from_slice(b" ");
+    });
+
+    unsafe { String::from_utf8_unchecked(result) }
+}
+
+// Notice the use of `split(|c| c == ' ')` - very handy function!
+pub fn rustlatin_fastester5(sentence: &str) -> String {
+    let mut result: String = String::with_capacity(sentence.len());
+    for word in sentence.split(|c| c == ' ') {
+        let vowel = word.starts_with(|c| is_vowel_fast4(c as u8));
+        if vowel {
+            result.push_str(&("sr".to_owned() + word + " "));
+        } else {
+            result.push_str(&(word.to_owned() + "rs "));
+        }
+    }
+    result
+}
+#[test]
+fn rustlatin_fastester2_test() {
+    use crate::*;
+    let s = "scope is hot";
+    assert_eq!(rustlatin_fastester2(s), "scopers sris hotrs");
+}
+#[test]
+fn rustlatin_fastester3_test() {
+    use crate::*;
+    let s = "scope is hot";
+    assert_eq!(rustlatin_fastester3(s), "scopers sris hotrs");
+}
+// Notice the trailing space - I guess it was left unspecified!
+// Just wanted to make sure I wasn't doing anything profane here
+#[test]
+fn rustlatin_fastester4_test() {
+    use crate::*;
+    let s = "scope is hot";
+    assert_eq!(rustlatin_fastester4(s), "scopers sris hotrs ");
+}
+#[test]
+fn rustlatin_fastester5_test() {
+    use crate::*;
+    let s = "scope is hot";
+    assert_eq!(rustlatin_fastester5(s), "scopers sris hotrs ");
 }
 
 pub fn rustlatin_rayon(sentence: &str) -> String {


### PR DESCRIPTION
Here's a few attempts that I tried.

I'm quite surprised `rustlatin_fastestet5` that doesn't go over the long string twice is not reasonably faster, but that might be a result of the problem size.

Notes:
1. Noodling in the stdlib can lead to some decent perf gains - the best addition I made was a simple `split_ascii_whitespace`! Edit: I haven't benchmarked with your home-cooked `simd_split_whitespace`, I don't know if that would help.
2. It took me a while to hit on the `split(|c| c == ' ')` idiom, but I'm quite satisfied with how that final version turns out for code cleanliness.
3. I didn't try most `rayon` methods - given that the longest input was 444k chars, I didn't think the startup time for a thread (~1micro second, iiuc) would payoff for this particular problem size. Bigger problems probably would! I can see a parallel approach where the input is chunked on the split regions, processed in parallel and join in a binary tree fashion respecting ordering. I want to look into `rayon` having some facilities to make that code amenable.
4. I think an "optimal" version of this code would use SIMD masking and swizzles, but I think I will leave that as a future exercise. 


----

Additional notes:
We left a couple of things unspecified!
1. We shouldn't worry about a trailing `' '`.
2. we should assume the only lowercase ascii letters and spaces are part of the input - some of the repeated `Lorem Ipsum`s would have `.Lorem` or something similar that would punk some of the vowel_first logic. I think those are fine to ignore.
3. Aside from Rust Godbolt or [cargo-show-asm](https://crates.io/crates/cargo-show-asm), I would try tools like [bytehound](https://github.com/koute/bytehound) to see if any specific patterns are allocating more memory than expected.
